### PR TITLE
Update route logic and permissions seeder

### DIFF
--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -97,7 +97,7 @@ class RolesAndPermissionsSeeder extends Seeder
         /* END BASE */
 
         /* START Courier */
-        "scan" => ["courier"],
+        "scan" => ["courier","airport"],
         /* END Courier */
 
         /* START Employees */

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,8 +39,8 @@ use App\Http\Controllers\CustomerController;
 
                 if (auth()->user()->hasPermissionTo('*')) {
                     return view('real-homepage');
-                } elseif (auth()->user()->hasAnyPermission(["courier.route", "scan.deliver", "courier.packages","scan"])) {
-                    return redirect()->route('workspace.courier.scan');
+                } elseif (auth()->user()->hasAnyPermission(["courier.route", "scan.deliver", "courier.packages"])) {
+                    return redirect()->route('workspace.courier');
                 } elseif (auth()->user()->hasAnyPermission(['HR.checkall',"HR.create", "HR.assign"])) {
                     return redirect()->route('workspace.employees.index');
                 } elseif (auth()->user()->hasAnyPermission(["pickup.view", "pickup.edit"])) {
@@ -105,7 +105,7 @@ use App\Http\Controllers\CustomerController;
 
             Route::post('/courier/submit-signature', [CourierRouteController::class, 'submitSignature'])->name('courier.submitSignature');
 
-            
+
 
 
             // Route::post('/update-package-status', [PackageController::class, 'updateStatus'])->name('package.update');


### PR DESCRIPTION
### Description

- Updated route redirection logic for courier users by removing the "scan" permission and redirecting to `workspace.courier` for streamlined handling of courier role access.
- Added the "airport" role to the scan permission within the `RolesAndPermissionsSeeder`, ensuring proper access for users with this role.