### PR TITLE
Update page titles for consistent branding

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
         @yield('meta')
-        <title>{{ config('app.name', 'Pickup Store Site') }} | @yield('title')</title>
+        <title>Blue Sky | @yield('title')</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/real-homepage.blade.php
+++ b/resources/views/real-homepage.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    @section('title', 'Blue Sky - Homepage')
+    @section('title', 'Homepage')
 
     <div class="flex flex-col items-center justify-center min-h-[calc(100vh-121px)] bg-gray-100">
 


### PR DESCRIPTION
Updated all page titles to align with "Blue Sky" branding. This change replaces hardcoded titles for a unified and professional appearance across the application.